### PR TITLE
[Fix] gtag

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -17,25 +17,28 @@ const { title } = Astro.props;
 		<title>{title}</title>
 		<!-- Google tag (gtag.js) -->
 
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-PSPHSKZ7K6"></script>
+<!-- Google tag (gtag.js) -->
+
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-94RY12H43C">
+</script>
+
 <script>
   interface Window {
     dataLayer: any[];
   }
-  declare global {
-    interface Window {
-      dataLayer: any[];
-    }
-  }
-  window.dataLayer = window.dataLayer || [];
-  function gtag(...args: any[]){(window.dataLayer as any[]).push(args);}
+
+  (window as unknown as Window).dataLayer = (window as unknown as Window).dataLayer || [];
+  function gtag(...args: any[]){(window as unknown as Window).dataLayer.push(args);}
   gtag('js', new Date());
-  gtag('config', 'G-PSPHSKZ7K6');
+
+  gtag('config', 'G-94RY12H43C');
 </script>
 	</head>
 	<body>
 		<slot />
 	</body>
+</html>
+</html>
 </html>
 <style is:global>
 	:root {


### PR DESCRIPTION
## PR Description

### Summary
This PR adds the **Google Tag Manager (gtag.js)** integration to the `Layout.astro` file. The Google Tag is now correctly placed in the `<head>` section of the layout, ensuring it is loaded across all pages using this layout.

### Changes
- Added the Google Tag script to the `<head>` section of the `Layout.astro` file.
- The tag ID used: `G-94RY12H43C`.

### Testing
1. **Local Testing:**
   - Run the project locally with `npm run dev` and verify the tag is correctly added by inspecting the network requests.
   - Confirm the tag is loaded by checking for requests to `www.googletagmanager.com` in the browser's network tab.

2. **Tag Assistant:**
   - Tested using **Google Tag Assistant** Chrome extension to ensure the tag is firing correctly.

3. **Google Analytics:**
   - Verified by checking **Real-Time data** in Google Analytics to see visits reflected from the site.

### Additional Notes
- This update is crucial for tracking user interactions and conversions on the website.
- Make sure the tag ID is correctly configured in Google Analytics for proper data collection.
